### PR TITLE
add item-body

### DIFF
--- a/js/helpers.js
+++ b/js/helpers.js
@@ -28,6 +28,21 @@ define([
       return t;
     },
 
+    toc__getBody: function(id, options) {
+      var model = Adapt.findById(id);
+      var t = model.get('body');
+      return t;
+    },
+
+    toc__exists: function(id, prop, options) {
+      var model = Adapt.findById(id);
+      if (model.get(prop)) {
+        return options.fn(this);
+      } else {
+        return options.inverse(this);
+      }
+    },
+
     toc__when: function(id, prop, options) {
       var model = Adapt.findById(id);
       if (model.get(prop)) {

--- a/less/toc.less
+++ b/less/toc.less
@@ -47,7 +47,8 @@
     justify-content: center;
   }
 
-  &__item-title {
+  &__item-title,
+  &__item-body {
     width: 75%;
   }
 
@@ -92,6 +93,12 @@
 // --------------------------------------------------
 
 .toc {
+  &__item-content {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 2;
+  }
+
   &__group-item-title {
     .button-text;
 

--- a/templates/partials/tocContentObjects.hbs
+++ b/templates/partials/tocContentObjects.hbs
@@ -15,12 +15,21 @@
       </span>
       {{/toc__isClickable}}
 
+      <div class="toc__item-content">
       <div class="toc__item-title drawer__item-title">
         <div class="toc__item-title-inner drawer__item-title-inner">
           {{{toc__getTitle this}}}
         </div>
       </div>
 
+        {{#toc__exists this "body"}}
+          <div class="toc__item-body drawer__item-body">
+            <div class="toc__item-body-inner drawer__item-body-inner">
+              {{{toc__getBody this}}}
+            </div>
+          </div>
+        {{/toc__exists}}
+      </div>
       {{#toc__when this "_isLocked"}}
       <div class="toc__item-icon">
         <div class="icon"></div>


### PR DESCRIPTION
This PR modifies the release/v5 branch.

This PR adds the content object's `body` if it exists. Additions were made to helpers.js in order to facilitate this. Styling for `toc__item-body` defaults to `drawer__item-body` following the model of` toc__item-title`.

![toc-pr](https://user-images.githubusercontent.com/9489014/162242154-b731226e-185e-465e-9117-b0e3e61e6344.jpg)

fixes #3
 