### PR TITLE
add item-subtitle and item-body

### DIFF
--- a/js/helpers.js
+++ b/js/helpers.js
@@ -28,6 +28,21 @@ define([
       return t;
     },
 
+    toc__getBody: function(id, options) {
+      var model = Adapt.findById(id);
+      var t = model.get('body');
+      return t;
+    },
+
+    toc__exists: function(id, prop, options) {
+      var model = Adapt.findById(id);
+      if (model.get(prop)) {
+        return options.fn(this);
+      } else {
+        return options.inverse(this);
+      }
+    },
+
     toc__when: function(id, prop, options) {
       var model = Adapt.findById(id);
       if (model.get(prop)) {

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -28,6 +28,12 @@ define([
       return t;
     },
 
+    toc__getSubtitle: function(id, options) {
+      var model = Adapt.findById(id);
+      var t = model.get('subtitle');
+      return t;
+    },
+
     toc__getBody: function(id, options) {
       var model = Adapt.findById(id);
       var t = model.get('body');

--- a/less/toc.less
+++ b/less/toc.less
@@ -48,6 +48,7 @@
   }
 
   &__item-title,
+  &__item-subtitle,
   &__item-body {
     width: 75%;
   }

--- a/less/toc.less
+++ b/less/toc.less
@@ -47,7 +47,8 @@
     justify-content: center;
   }
 
-  &__item-title {
+  &__item-title,
+  &__item-body {
     width: 75%;
   }
 
@@ -92,6 +93,12 @@
 // --------------------------------------------------
 
 .toc {
+  &__item-content {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 2;
+  }
+
   &__group-item-title {
     .button-text;
 

--- a/templates/partials/tocContentObjects.hbs
+++ b/templates/partials/tocContentObjects.hbs
@@ -15,12 +15,21 @@
       </span>
       {{/toc__isClickable}}
 
+      <div class="toc__item-content">
       <div class="toc__item-title drawer__item-title">
         <div class="toc__item-title-inner drawer__item-title-inner">
           {{{toc__getTitle this}}}
         </div>
       </div>
 
+        {{#toc__exists this "body"}}
+          <div class="toc__item-body drawer__item-body">
+            <div class="toc__item-body-inner drawer__item-body-inner">
+              {{{toc__getBody this}}}
+            </div>
+          </div>
+        {{/toc__exists}}
+      </div>
       {{#toc__when this "_isLocked"}}
       <div class="toc__item-icon">
         <div class="icon"></div>

--- a/templates/partials/tocContentObjects.hbs
+++ b/templates/partials/tocContentObjects.hbs
@@ -22,6 +22,14 @@
         </div>
       </div>
 
+        {{#toc__exists this "subtitle"}}
+          <div class="toc__item-subtitle drawer__item-title">
+            <div class="toc__item-subtitle-inner drawer__item-title-inner">
+              {{{toc__getSubtitle this}}}
+            </div>
+          </div>
+        {{/toc__exists}}
+
         {{#toc__exists this "body"}}
           <div class="toc__item-body drawer__item-body">
             <div class="toc__item-body-inner drawer__item-body-inner">


### PR DESCRIPTION
This PR is based on the release/v5 branch.

This PR adds `subtitle` and `body` as optional content.

Currently `toc__item-title` gets default styling from `drawer__item-title`. It's a nice way to keep styles in sync. I did the same with `toc__item-body` by using `drawer__item-body`. However, there's nothing similar in drawer for `subtitle`. Consequently, I reused `drawer__item-title`. I do not think this is ideal, but it provides some base styling.

![toc-pr](https://user-images.githubusercontent.com/9489014/162282237-8070d807-d600-4522-a9dc-7779dae21300.jpg)

fixes #3 
