### PR TITLE
Auto-Grouping functionality

### DIFF
--- a/example.json
+++ b/example.json
@@ -4,7 +4,18 @@
     "_toc": {
         "_excludeContentObjects": []
     }
-
+	
+    // hierarchical structure: content objects are grouped automatically
+    // _autoGrouping (if _enabled) reflects the menu, page, article, block, component structure of adapt courses
+    // _maxLevel defines how deep the nested autoGroups should be
+    // 0 => menu/page; 1 => article; 2 => block; 3 => component
+    "_toc": {
+        "_autoGrouping": {
+            "_enabled": true,
+            "_maxLevel": 0
+        }
+    }
+	
     // in most scenarios it is necessary to specify a redirection page
     "_start": {
         "_isEnabled": true,

--- a/js/tocView.js
+++ b/js/tocView.js
@@ -51,18 +51,130 @@ define([
       Adapt.trigger('drawer:setDrawerDir');
       Backbone.View.prototype.remove.apply(this, arguments);
     },
+	
+    childParentMapping: function(root, map = []) {
+      const children = root.getChildren();
+		
+      children.models.forEach(child => {
+        map.push({id: child.get('_id'), parentId: root.get('_id'), obj: child});
 
+        if (child.hasManagedChildren) {
+          this.childParentMapping(child, map);
+        }
+      });
+		
+      return map;
+    },
+	
+    treeMapping: function(childParentMapping) {
+      // source: https://typeofnan.dev/an-easy-way-to-build-a-tree-with-object-references/
+      const idMapping = childParentMapping.reduce((acc, el, i) => {
+        acc[el.id] = i;
+        return acc;
+      }, {});
+		
+      let root;
+		
+      childParentMapping.forEach((el) => {
+        // Handle the root element
+        if (el.parentId === null) {
+          root = el;
+          return;
+	}
+	// Use our mapping to locate the parent element in our data array
+	const parentEl = childParentMapping[idMapping[el.parentId]];
+	// Add our current el to its parent's `children` array
+	parentEl.children = [...(parentEl.children || []), el];
+      });
+
+      return root;
+    },
+
+    cleanUp: function(node) {
+      if (!node._contentObjects.length > 0) {
+        delete node._contentObjects;
+      }
+
+      if (!node._grouping._items.length > 0) {
+        delete node._grouping;
+      }
+
+      delete node.parentId;
+      delete node.children;
+      delete node.obj;
+
+      return node;
+    },
+	
+    addMeta: function(node, ariaLevel, maxLevel) {
+      node.title = node.obj.get('title');
+      node._classes = '';
+      node._ariaLevel = ariaLevel;
+
+      node._contentObjects = [];
+      node._grouping = {"_classes": "", "_items": []};
+
+      typeGroups = ['menu', 'page', 'article', 'block', 'component'];
+
+      if (typeGroups.indexOf(node.obj.getTypeGroup()) > maxLevel) {
+        return this.cleanUp(node);
+      } else {
+        node.children.forEach(child => {
+          if ((!child.obj.hasManagedChildren) || typeGroups.indexOf(child.obj.getTypeGroup()) > maxLevel) {
+            node._contentObjects.push(child.id);
+          } else {
+            node._grouping._items.push(Object.assign({}, child, this.addMeta(child, ariaLevel+1, maxLevel)));
+          }
+        });
+      }
+
+      return this.cleanUp(node);
+    },
+	
+    buildGrouping: function(treeMapping, ariaLevel = 1, maxLevel) {
+      treeMapping.children.forEach(node => {
+        node = this.addMeta(node, ariaLevel, maxLevel);
+      });
+	  
+      return treeMapping;
+    },
+    
     getGroups: function(config) {
       if (config._grouping) {
         return config._grouping;
+      } else if (config._autoGrouping._enabled) {
+        map = this.childParentMapping(Adapt.course);
+        
+        map.push({id: Adapt.course.get('_id'), parentId: null});
+        
+        // maxLevel: 0 => menu/page; 1 => article; 2 => block; 3 => component
+        var preResult = this.buildGrouping(
+          this.treeMapping(map),
+          ariaLevel = 1,
+          maxLevel = config._autoGrouping._maxLevel
+        );
+        
+        var result = [];
+        
+        preResult.children.forEach(child => {
+          if (child._contentObjects || child._grouping) {
+              result.push(child);
+          } else {
+              result.push({"_ariaLevel": 1, "_classes": '', "_contentObjects": [child.id]});
+          }
+        });
+        
+        return {
+          "_classes": config._classes,
+          "_items": result
+        };
+      } else {
+        return {
+          "_classes": config._classes,
+          "_items": [{'_contentObjects': _.difference(Adapt.contentObjects.pluck('_id'), config._excludeContentObjects)}]
+        };
       }
-
-      return {
-        "_classes": config._classes,
-        "_items": [{'_contentObjects': _.difference(Adapt.contentObjects.pluck('_id'), config._excludeContentObjects)}]
-      };
     }
-
   });
 
   return TocView;

--- a/properties.schema
+++ b/properties.schema
@@ -74,7 +74,30 @@
                     "mode": "json"
                   },
                   "help": "Configure the visual organisation of content objects (see example.json)."
-                }
+                },
+				"_autoGrouping": {
+                  "type": "object",
+				  "required": false,
+				  "legend": "Auto-Grouping",
+                  "properties": {
+				    "_enabled": {
+					  "type": "boolean",
+				      "required": true,
+					  "default": false,
+					  "title": "Is Enabled",
+					  "inputType": "Checkbox",
+					  "help": "If this option is enabled the ToC will reflect the menu, page, article, block, component structure of the course."
+					},
+					"_maxLevel": {
+					  "type": "integer",
+				      "required": true,
+					  "default": 0,
+					  "title": "Maximum Nesting Level",
+					  "inputType": {"type": "Select", "options":[0, 1, 2, 3]},
+					  "help": "This option defines how deep the nested autoGroups should be: 0 => menu/page; 1 => article; 2 => block; 3 => component."
+					}
+				  }
+				}
               }
             }
           }


### PR DESCRIPTION
Hello,

first of all I would like to thank you for developing this plugin. In our project we wanted to implement something similar to the [adapt-contents](https://github.com/KingsOnline/adapt-contents) plugin. Since the adapt-contents plugin was not compatible with the current Adapt framework version, we found this repository, but we were missing an auto-grouping functionality that reflects the course structure. This pull request is intended to solve this problem. The auto-grouping functionality is added as an option in the course.json configuration ("_enabled": true; see example.json), leaving the other options untouched. The "_maxLevel" defines how deep the nested autoGroups should be / where the cutoff for contentObjects should be: 0 => menu/page; 1 => article; 2 => block; 3 => component.  

The following graphic is intended to demonstrate the functionality symbolically; the CSS used to visually distinguish the contentObjects from the groups is not part of the pull request.  

![grafik](https://user-images.githubusercontent.com/25271469/187708312-61a67b07-ddde-4dfc-9e23-a39520dff6b8.png)
