### PR TITLE
Fix: Bump required framework version to 5.30.2 (fixes #9)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-toc",
   "version": "1.0.3",
-  "framework": ">=5.22.9",
+  "framework": ">=5.30.2",
   "homepage": "https://github.com/cgkineo/adapt-toc",
   "issues": "https://github.com/cgkineo/adapt-toc/issues",
   "extension": "toc",


### PR DESCRIPTION
Fix #9 

### Fix
* Bumps required framework version to [5.30.2](https://github.com/adaptlearning/adapt_framework/releases/tag/v5.30.2) for Tooltip API support