### PR TITLE
Fix: Fix grouped / sub topic body alignment, progress bar width (fixes #14)

### DIFF
--- a/less/toc.less
+++ b/less/toc.less
@@ -69,7 +69,6 @@
 
 // duplicate of pageLevelProgressIndicator.less
 // --------------------------------------------------
-
 .toc {
   &__indicator {
     width: 2rem;

--- a/less/toc.less
+++ b/less/toc.less
@@ -76,6 +76,10 @@
     border: 0.0625rem solid @black;
     border-radius: 50px;
     overflow: hidden;
+
+    .drawer & {
+      margin: 0;
+    }
   }
 
   &__indicator-inner {
@@ -115,6 +119,7 @@
 // --------------------------------------------------
 .toc {
   &__indicator {
+    min-width: 2rem;
     border-color: @progress-border;
   }
 

--- a/less/toc.less
+++ b/less/toc.less
@@ -12,8 +12,9 @@
 // --------------------------------------------------
 .toc__group-item .toc__group {
   .toc__group-item-title,
-  .toc__item-title-inner {
-    text-indent: 1rem;
+  .toc__item-title-inner,
+  .toc__item-body-inner {
+    padding-inline-start: 1rem;
   }
 }
 

--- a/less/toc.less
+++ b/less/toc.less
@@ -69,17 +69,6 @@
 
 // duplicate of pageLevelProgressIndicator.less
 // --------------------------------------------------
-.drawer .toc {
-  &__item-title,
-  &__item-subtitle,
-  &__item-body {
-    width: 100%;
-  }
-
-  &__indicator {
-    margin-right: 0;
-  }
-}
 
 .toc {
   &__indicator {
@@ -105,6 +94,18 @@
 // --------------------------------------------------
 // THEME
 // --------------------------------------------------
+
+.drawer .toc {
+  &__item-title,
+  &__item-subtitle,
+  &__item-body {
+    width: 100%;
+  }
+
+  &__indicator {
+    margin-right: 0;
+  }
+}
 
 .toc {
   &__item-content {

--- a/less/toc.less
+++ b/less/toc.less
@@ -100,10 +100,6 @@
   &__item-body {
     width: 100%;
   }
-
-  &__indicator {
-    margin-right: 0;
-  }
 }
 
 .toc {

--- a/less/toc.less
+++ b/less/toc.less
@@ -69,6 +69,18 @@
 
 // duplicate of pageLevelProgressIndicator.less
 // --------------------------------------------------
+.drawer .toc {
+  &__item-title,
+  &__item-subtitle,
+  &__item-body {
+    width: 100%;
+  }
+
+  &__indicator {
+    margin-right: 0;
+  }
+}
+
 .toc {
   &__indicator {
     width: 2rem;
@@ -76,10 +88,6 @@
     border: 0.0625rem solid @black;
     border-radius: 50px;
     overflow: hidden;
-
-    .drawer & {
-      margin: 0;
-    }
   }
 
   &__indicator-inner {


### PR DESCRIPTION
Fixes #14 

### Fix
* Fix grouped / sub topic title and body alignment
* Fix progress bar widths
* Note that I had to break away from some of the [Page Level Progress styles](https://github.com/adaptlearning/adapt-contrib-pageLevelProgress/tree/master/less). Open to suggestions for how to keep this more closely aligned.

### Testing
See #14 example JSON

### Screenshot (with fixes)
<img src="https://github.com/cgkineo/adapt-toc/assets/898168/1923ea73-7aaa-4a2f-81bc-fb6f770a9c6e" width="350">
