### PR TITLE
New: Add _isEnabled option (fixes #18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ The following attributes, set within *course.json*, configure the defaults for *
 
 The `_toc` object contains the following settings:
 
+#### **\_isEnabled** (boolean)
+
+Turns on and off the **ToC** extension.
+
 #### **\_drawerPosition** (string)
 
 The position that the button appears in the drawer. Position options include `auto`, `left`, and `right`. Defaults to `auto`

--- a/example.json
+++ b/example.json
@@ -13,6 +13,7 @@
 
     // custom structure: specify a hierarchy by defining groups of content objects
     "_toc": {
+        "_isEnabled": true,
         "_drawerPosition": "auto",
         "_grouping": {
             "_classes": "",

--- a/js/tocNavigationView.js
+++ b/js/tocNavigationView.js
@@ -17,6 +17,9 @@ define([
     },
 
     initialize: function() {
+      var cfg = Adapt.course.get('_toc') || {};
+      if (!cfg || cfg._isEnabled === false) return;
+
       this.$el.attr('role', 'button');
       this.ariaText = '';
 

--- a/properties.schema
+++ b/properties.schema
@@ -77,6 +77,13 @@
               "type": "object",
               "legend": "TOC",
               "properties": {
+                "_isEnabled": {
+                  "type": "boolean",
+                  "default": true,
+                  "title": "Enable TOC",
+                  "inputType": "Checkbox",
+                  "validators": []
+                },
                 "_drawerPosition": {
                   "type": "string",
                   "required": true,


### PR DESCRIPTION
Fix #18 

### New
* Adds an `_isEnabled` option to enable or disable the navigation button

### Testing
In _course.json_, add the `_toc._isEnabled` as shown in the _example.json_.
