### PR TITLE
Fix: Replace deprecated drawer.triggerCustomView with drawer.openCustomView (fixes #23)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 * A sentence describing each fix
 
 ### Update
-* A sentence describing each udpate
+* A sentence describing each update
 
 ### New
 * A sentence describing each new feature

--- a/js/tocNavigationView.js
+++ b/js/tocNavigationView.js
@@ -51,7 +51,7 @@ define([
       var cfg = Adapt.course.get('_toc') || {}
       var position = cfg._drawerPosition || 'auto'
       // here is where you might customise what toc renders if so desired
-      Adapt.drawer.triggerCustomView(new TocView({cfg}).$el, false, position);
+      Adapt.drawer.openCustomView(new TocView({cfg}).$el, false, position);
     }
 
   });


### PR DESCRIPTION
Fix #23 

### Fix
* Replaces deprecated `drawer.triggerCustomView` with `drawer.openCustomView`
